### PR TITLE
Add a target to make 'developer-setup' runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+create-pre-commit-hooks: ## creates pre-commit hooks
+	chmod +x $(CURDIR)/hooks/pre-commit
+	ln -s $(CURDIR)/hooks/pre-commit .git/hooks/pre-commit || true
+
 deps:
 	glide install
 


### PR DESCRIPTION
Currently the `Makefile` provides only `deps` target, in spite of the `Makefile` in `k8guard-start-from-here` repo requires `create-pre-commit-hooks` target.

https://github.com/k8guard/k8guard-start-from-here/blob/master/Makefile#L32